### PR TITLE
Fixed background color assignment in compareTimeWithCurrent function

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -61,13 +61,14 @@ function compareTimeWithCurrent() {
 $('.time').each(function(){
     //Get the value of the data-hour attribute
     var hourValue = parseInt($(this).attr('data-hour'));
+    var textarea = $(this).closest('tr').find('.form-control');
 
     if (hourValue < currentHour) {
-        $('.form-control').addClass('past'); // Change to your desired color
-    } else if (hourValue === currentHour) {
-        $('.form-control').addClass('present'); // Change to your desired color
-    } else {
-        $('.form-control').addClass('future'); // Change to your desired color
+        textarea.addClass('past'); // Change to your desired color
+    }else if (hourValue === currentHour) {
+        textarea.addClass('present'); // Change to your desired color
+    }else{
+        textarea.addClass('future'); // Change to your desired color
     }
 })
 }


### PR DESCRIPTION
I Updated the compareTimeWithCurrent function to correctly apply background colors to the textarea based on the comparison result.

- The previous code applied background colors to all elements with the class '.form-control', regardless of the specific row.
- The updated code targets the '.form-control' element within the current row, ensuring that the background color is applied only to the relevant textarea.

**Changes:**

Modified the selector to target the specific '.form-control' element within the current row using closest() and find().
